### PR TITLE
Remove redundant packages from requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A serverless application that automatically tracks and stores completion statistics for the Sudoku puzzle in the [New York Times games](https://www.nytco.com/games/) mobile app. 
 
-Results are stored in a database, and displayed in Grafana. My personal dashboard can be found [here](https://sudokutracker.grafana.net/public-dashboards/021f11e0932e4ed6b98887bf008fc8de). 
+Results can be displayed in Grafana; my personal dashboard can be found [here](https://sudokutracker.grafana.net/public-dashboards/021f11e0932e4ed6b98887bf008fc8de). 
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A serverless application that automatically tracks and stores completion statistics for the Sudoku puzzle in the [New York Times games](https://www.nytco.com/games/) mobile app. 
 
-Results can be displayed in Grafana; my personal dashboard can be found [here](https://sudokutracker.grafana.net/public-dashboards/021f11e0932e4ed6b98887bf008fc8de). 
+Results can be displayed in Grafana; my personal dashboard can be found [here](https://sudokutracker.grafana.net/public-dashboards/021f11e0932e4ed6b98887bf008fc8de) 📈. 
 
 ## Architecture Overview
 
@@ -47,7 +47,10 @@ Follow the [Google Cloud Run continuous deployment guide](https://cloud.google.c
 - **Timeout**: 3000 seconds (adjust as needed)
 
 #### Security
-- **Service Account**: Select your designated service account with appropriate permissions (at least secret manager accessor)
+- **Service Account**: Select your designated service account with appropriate permissions, at least:
+    - Secret accessor
+    - Logs writer
+    - Artifact registry writer + createOnPush
 
 #### Environment Variables
 - None needed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sudoku Stats Tracker
 
-A serverless application that automatically tracks and stores completion statistics for the Sudoku puzzle in the New York Times games app. 
+A serverless application that automatically tracks and stores completion statistics for the Sudoku puzzle in the [New York Times games](https://www.nytco.com/games/) mobile app. 
 
 Results are stored in a database, and displayed in Grafana. My personal dashboard can be found [here](https://sudokutracker.grafana.net/public-dashboards/021f11e0932e4ed6b98887bf008fc8de). 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pre-commit==3.8.0
+ruff==0.6.9
+mypy==1.11.2
+types-request

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,21 +3,10 @@ google-cloud-secret-manager==2.20.2
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
-google-cloud-storage
-google-cloud-bigquery
-cloud-sql-python-connector
-pg8000>=1.29.0  # A pure Python PostgreSQL driver that works well with Cloud SQL
 pydantic==2.9.2
-beautifulsoup4
-pytz
-opnieuw
 functions-framework==3.*
 Flask==3.0.3
 anthropic>=0.18.0
 Pillow>=11.3.0
 sqlalchemy==2.0.27
 psycopg2-binary==2.9.9
-pre-commit==3.8.0
-ruff==0.6.9
-mypy==1.11.2
-types-request


### PR DESCRIPTION
I've previously blindly copy-pasted requirements from another project, forgetting to clean up the list. This cleans up the list to packages we really need. I've moved the packages for type checking, linting and formatting to a separate file, to not let Google Cloud Run trip up over these. 